### PR TITLE
Initial implementation of finite-difference gradient approximations for likelihood

### DIFF
--- a/src/dalia/configs/likelihood_config.py
+++ b/src/dalia/configs/likelihood_config.py
@@ -18,6 +18,7 @@ class LikelihoodConfig(BaseModel, ABC):
     model_config = ConfigDict(extra="forbid")
 
     type: Literal["gaussian", "poisson", "binomial"] = None
+    method: Literal["exact", "finite_difference"] = "exact"
 
     # TODO: cleaner way to let user fix hyperparameters
     fix_hyperparameters: bool = False

--- a/src/dalia/core/likelihood.py
+++ b/src/dalia/core/likelihood.py
@@ -18,6 +18,24 @@ class Likelihood(ABC):
 
         self.config = config
         self.n_observations = n_observations
+    
+    def gradient_likelihood(self, eta, y, h=1e-4, **kwargs):
+        if self.config.method == "exact":
+            return self.evaluate_gradient_likelihood(eta, y, **kwargs)
+        elif self.config.method == "finite_difference":
+            grad = self.finite_difference_gradient_likelihood(eta, y, h, **kwargs)
+            return grad
+        else:
+            raise NotImplementedError(f"Method {self.config.method} not implemented.")
+    
+    def hessian_likelihood(self, eta, y, h=1e-4, **kwargs):
+        if self.config.method == "exact":
+            return self.evaluate_hessian_likelihood(eta, y, **kwargs)
+        elif self.config.method == "finite_difference":
+            hess = self.finite_difference_hessian_likelihood(eta, y, h, **kwargs)
+            return hess
+        else:
+            raise NotImplementedError(f"Method {self.config.method} not implemented.")
 
     @abstractmethod
     def evaluate_likelihood(
@@ -68,7 +86,41 @@ class Likelihood(ABC):
         gradient_likelihood : NDArray
             Gradient of the likelihood.
         """
-        pass
+        self.finite_difference_gradient_likelihood(eta, y, **kwargs)
+
+    def finite_difference_gradient_likelihood(
+            self,
+            eta: NDArray,
+            y: NDArray,
+            h: float = 1e-4,
+            **kwargs,
+    ) -> NDArray:
+        """Evaluate the finite difference gradient of the likelihood wrt to eta = Ax.
+
+        Parameters
+        ----------
+        eta : NDArray
+            Vector of the linear predictor.
+        y : NDArray
+            Vector of the observations.
+        **kwargs : optional
+            Hyperparameters for likelihood.
+
+        Returns
+        -------
+        finite_difference_gradient : NDArray
+            Finite difference gradient of the likelihood.
+        """
+        # grad = (-f(x+2h) + 8f(x+h) - 8f(x-h) + f(x-2h)) / 12h
+        # hessian = (-f(x+2h) + 16f(x+h) - 30f(x) + 16f(x-h) - f(x-2h)) / 12h^2
+        f1 = self.evaluate_likelihood(eta + h, y, **kwargs)
+        f2 = self.evaluate_likelihood(eta + 2 * h, y, **kwargs)
+        b1 = self.evaluate_likelihood(eta - h, y, **kwargs)
+        b2 = self.evaluate_likelihood(eta - 2 * h, y, **kwargs)
+        # c = self.evaluate_likelihood(eta, y, **kwargs)
+        grad = (-f2 + 8 * f1 - 8 * b1 + b2) / (12 * h)
+        # hessian = (-f2 + 16 * f1 - 30 * c + 16 * b1 - b2) / (12 * h * h)
+        return grad
 
     @abstractmethod
     def evaluate_hessian_likelihood(
@@ -92,4 +144,38 @@ class Likelihood(ABC):
         hessian_likelihood : ArrayLike
             Hessian of the likelihood.
         """
-        pass
+        self.finite_difference_hessian_likelihood(eta, y, **kwargs)
+
+    def finite_difference_hessian_likelihood(
+            self,
+            eta: NDArray,
+            y: NDArray,
+            h: float = 1e-4,
+            **kwargs,
+    ) -> NDArray:
+        """Evaluate the finite difference Hessian of the likelihood wrt to eta = Ax.
+
+        Parameters
+        ----------
+        eta : NDArray
+            Vector of the linear predictor.
+        y : NDArray
+            Vector of the observations.
+        **kwargs : optional
+            Hyperparameters for likelihood.
+
+        Returns
+        -------
+        finite_difference_gradient : NDArray
+            Finite difference gradient of the likelihood.
+        """
+        # grad = (-f(x+2h) + 8f(x+h) - 8f(x-h) + f(x-2h)) / 12h
+        # hessian = (-f(x+2h) + 16f(x+h) - 30f(x) + 16f(x-h) - f(x-2h)) / 12h^2
+        f1 = self.evaluate_likelihood(eta + h, y, **kwargs)
+        f2 = self.evaluate_likelihood(eta + 2 * h, y, **kwargs)
+        b1 = self.evaluate_likelihood(eta - h, y, **kwargs)
+        b2 = self.evaluate_likelihood(eta - 2 * h, y, **kwargs)
+        c = self.evaluate_likelihood(eta, y, **kwargs)
+        # grad = (-f2 + 8 * f1 - 8 * b1 + b2) / (12 * h)
+        hessian = (-f2 + 16 * f1 - 30 * c + 16 * b1 - b2) / (12 * h * h)
+        return hessian

--- a/src/dalia/core/likelihood.py
+++ b/src/dalia/core/likelihood.py
@@ -2,7 +2,7 @@
 
 from abc import ABC, abstractmethod
 
-from dalia import ArrayLike, NDArray, xp,sp
+from dalia import ArrayLike, NDArray
 from dalia.configs.likelihood_config import LikelihoodConfig
 
 
@@ -18,7 +18,7 @@ class Likelihood(ABC):
 
         self.config = config
         self.n_observations = n_observations
-    
+
     def gradient_likelihood(self, eta, y, h=1e-4, **kwargs):
         if self.config.method == "exact":
             return self.evaluate_gradient_likelihood(eta, y, **kwargs)
@@ -77,7 +77,7 @@ class Likelihood(ABC):
             Likelihood.
         """
         pass
-     
+
     def evaluate_sum_likelihood(
         self,
         eta: NDArray,
@@ -105,7 +105,6 @@ class Likelihood(ABC):
         sum_likelihood = float(likelihood.sum())
         return sum_likelihood
 
-    @abstractmethod
     def evaluate_gradient_likelihood(
         self,
         eta: NDArray,
@@ -116,10 +115,10 @@ class Likelihood(ABC):
 
         Parameters
         ----------
-        y : NDArray
-            Vector of the observations.
         eta : NDArray
             Vector of the linear predictor.
+        y : NDArray
+            Vector of the observations.
         **kwargs : optional
             Hyperparameters for likelihood.
 
@@ -131,11 +130,11 @@ class Likelihood(ABC):
         self.finite_difference_gradient_likelihood(eta, y, **kwargs)
 
     def finite_difference_gradient_likelihood(
-            self,
-            eta: NDArray,
-            y: NDArray,
-            h: float = 1e-4,
-            **kwargs,
+        self,
+        eta: NDArray,
+        y: NDArray,
+        h: float = 1e-4,
+        **kwargs,
     ) -> NDArray:
         """Evaluate the finite difference gradient of the likelihood wrt to eta = Ax.
 
@@ -145,6 +144,8 @@ class Likelihood(ABC):
             Vector of the linear predictor.
         y : NDArray
             Vector of the observations.
+        h : float
+            Finite difference step size.
         **kwargs : optional
             Hyperparameters for likelihood.
 
@@ -152,21 +153,24 @@ class Likelihood(ABC):
         -------
         finite_difference_gradient : NDArray
             Finite difference gradient of the likelihood.
+
+        Notes
+        -----
+        The Gradient of the likelihood is computed using a five-point stencil as follows:
+
+        .. math:: \grad{f}=\frac{-f(x+2h) + 8f(x+h) - 8f(x-h) + f(x-2h)}{12h}
         """
-        # grad = (-f(x+2h) + 8f(x+h) - 8f(x-h) + f(x-2h)) / 12h
-        # hessian = (-f(x+2h) + 16f(x+h) - 30f(x) + 16f(x-h) - f(x-2h)) / 12h^2
         f1 = self.evaluate_likelihood(eta + h, y, **kwargs)
         f2 = self.evaluate_likelihood(eta + 2 * h, y, **kwargs)
         b1 = self.evaluate_likelihood(eta - h, y, **kwargs)
         b2 = self.evaluate_likelihood(eta - 2 * h, y, **kwargs)
-        # c = self.evaluate_likelihood(eta, y, **kwargs)
         grad = (-f2 + 8 * f1 - 8 * b1 + b2) / (12 * h)
-        # hessian = (-f2 + 16 * f1 - 30 * c + 16 * b1 - b2) / (12 * h * h)
         return grad
 
-    @abstractmethod
     def evaluate_hessian_likelihood(
         self,
+        eta: NDArray,
+        y: NDArray,
         **kwargs,
     ) -> ArrayLike:
         """Evaluate the Hessian of the likelihood wrt to eta = Ax.
@@ -180,7 +184,6 @@ class Likelihood(ABC):
         **kwargs : optional
             Hyperparameters for likelihood.
 
-
         Returns
         -------
         hessian_likelihood : ArrayLike
@@ -189,11 +192,11 @@ class Likelihood(ABC):
         self.finite_difference_hessian_likelihood(eta, y, **kwargs)
 
     def finite_difference_hessian_likelihood(
-            self,
-            eta: NDArray,
-            y: NDArray,
-            h: float = 1e-2,
-            **kwargs,
+        self,
+        eta: NDArray,
+        y: NDArray,
+        h: float = 1e-2,
+        **kwargs,
     ) -> NDArray:
         """Evaluate the finite difference Hessian of the likelihood wrt to eta = Ax.
 
@@ -203,21 +206,26 @@ class Likelihood(ABC):
             Vector of the linear predictor.
         y : NDArray
             Vector of the observations.
+        h : float
+            Finite difference step size.
         **kwargs : optional
             Hyperparameters for likelihood.
 
         Returns
         -------
-        finite_difference_gradient : NDArray
-            Finite difference gradient of the likelihood.
+        finite_difference_hessian : NDArray
+            Finite difference hessian of the likelihood.
+
+        Notes
+        -----
+        The Hessian of the likelihood is computed using a five-point stencil as follows:
+
+        .. math:: \hess{f}=\frac{-f(x+2h) + 16f(x+h) - 30f(x) + 16f(x-h) - f(x-2h)}{12h^2}
         """
-        # grad = (-f(x+2h) + 8f(x+h) - 8f(x-h) + f(x-2h)) / 12h
-        # hessian = (-f(x+2h) + 16f(x+h) - 30f(x) + 16f(x-h) - f(x-2h)) / 12h^2
         f1 = self.evaluate_likelihood(eta + h, y, **kwargs)
         f2 = self.evaluate_likelihood(eta + 2 * h, y, **kwargs)
         b1 = self.evaluate_likelihood(eta - h, y, **kwargs)
         b2 = self.evaluate_likelihood(eta - 2 * h, y, **kwargs)
         c = self.evaluate_likelihood(eta, y, **kwargs)
-        # grad = (-f2 + 8 * f1 - 8 * b1 + b2) / (12 * h)
         hessian = (-f2 + 16 * f1 - 30 * c + 16 * b1 - b2) / (12 * h * h)
         return hessian

--- a/src/dalia/core/likelihood.py
+++ b/src/dalia/core/likelihood.py
@@ -2,7 +2,7 @@
 
 from abc import ABC, abstractmethod
 
-from dalia import ArrayLike, NDArray
+from dalia import ArrayLike, NDArray, xp,sp
 from dalia.configs.likelihood_config import LikelihoodConfig
 
 
@@ -27,15 +27,30 @@ class Likelihood(ABC):
             return grad
         else:
             raise NotImplementedError(f"Method {self.config.method} not implemented.")
-    
-    def hessian_likelihood(self, eta, y, h=1e-4, **kwargs):
+        # ref = self.evaluate_gradient_likelihood(eta, y, **kwargs)
+        # grad = self.finite_difference_gradient_likelihood(eta, y, h, **kwargs)
+        # assert xp.allclose(ref, grad), f"Gradient mismatch: {ref} vs {grad}"
+        # return grad
+
+    def hessian_likelihood(self, h: float = 1e-2, **kwargs):
         if self.config.method == "exact":
-            return self.evaluate_hessian_likelihood(eta, y, **kwargs)
+            return self.evaluate_hessian_likelihood(**kwargs)
         elif self.config.method == "finite_difference":
-            hess = self.finite_difference_hessian_likelihood(eta, y, h, **kwargs)
+            kwargs = kwargs or {}
+            kwargs["h"] = h
+            hess = self.finite_difference_hessian_likelihood(**kwargs)
             return hess
         else:
             raise NotImplementedError(f"Method {self.config.method} not implemented.")
+        # ref = self.evaluate_hessian_likelihood(**kwargs)
+        # ref_diag = ref.diagonal()
+        # kwargs = kwargs or {}
+        # kwargs["h"] = 1e-3
+        # hess = self.finite_difference_hessian_likelihood(**kwargs)
+        # rel_error = xp.linalg.norm(ref_diag - hess) / xp.linalg.norm(ref_diag)
+        # if not xp.allclose(ref_diag, hess):
+        #     print(f"Hessian mismatch: {rel_error}")
+        # return hess
 
     @abstractmethod
     def evaluate_likelihood(
@@ -43,7 +58,7 @@ class Likelihood(ABC):
         eta: NDArray,
         y: NDArray,
         **kwargs,
-    ) -> float:
+    ) -> NDArray:
         """Evaluate the likelihood.
 
         Parameters
@@ -62,6 +77,33 @@ class Likelihood(ABC):
             Likelihood.
         """
         pass
+     
+    def evaluate_sum_likelihood(
+        self,
+        eta: NDArray,
+        y: NDArray,
+        **kwargs,
+    ) -> float:
+        """Evaluate the sum of the likelihood over all observations.
+
+        Parameters
+        ----------
+        eta : NDArray
+            Vector of the linear predictor.
+        y : NDArray
+            Vector of the observations.
+        kwargs :
+            theta : float
+                Specific parameter for the likelihood calculation.
+
+        Returns
+        -------
+        sum_likelihood : float
+            Sum of the likelihood over all observations.
+        """
+        likelihood = self.evaluate_likelihood(eta, y, **kwargs)
+        sum_likelihood = float(likelihood.sum())
+        return sum_likelihood
 
     @abstractmethod
     def evaluate_gradient_likelihood(
@@ -150,7 +192,7 @@ class Likelihood(ABC):
             self,
             eta: NDArray,
             y: NDArray,
-            h: float = 1e-4,
+            h: float = 1e-2,
             **kwargs,
     ) -> NDArray:
         """Evaluate the finite difference Hessian of the likelihood wrt to eta = Ax.

--- a/src/dalia/core/model.py
+++ b/src/dalia/core/model.py
@@ -431,7 +431,7 @@ class Model(ABC):
             d_matrix = self.submodels[0].evaluate_d_matrix(**kwargs)
         else:
             # General rules
-            d_matrix = self.likelihood.evaluate_hessian_likelihood(**kwargs)
+            d_matrix = self.likelihood.hessian_likelihood(**kwargs)
 
         # if self.a is sparse -> Q_conditional should be sparse, else dense
         if sp.sparse.issparse(self.a):
@@ -467,7 +467,7 @@ class Model(ABC):
             )
 
         else:
-            gradient_likelihood = self.likelihood.evaluate_gradient_likelihood(
+            gradient_likelihood = self.likelihood.gradient_likelihood(
                 eta=eta,
                 y=self.y,
                 theta=self.theta[self.hyperparameters_idx[-1] :],

--- a/src/dalia/core/model.py
+++ b/src/dalia/core/model.py
@@ -431,19 +431,30 @@ class Model(ABC):
             d_matrix = self.submodels[0].evaluate_d_matrix(**kwargs)
         else:
             # General rules
+            kwargs["y"] = self.y
             d_matrix = self.likelihood.hessian_likelihood(**kwargs)
+        
+        if d_matrix.ndim == 1:
+            d_matrix_diagonal_0 = d_matrix[0]
+            d_matrix = sp.sparse.diags(d_matrix)
+        elif d_matrix.ndim == 2:
+            d_matrix_diagonal_0 = d_matrix.diagonal()[0]
+        else:
+            raise ValueError("d_matrix must be 1D or 2D array.")
 
         # if self.a is sparse -> Q_conditional should be sparse, else dense
         if sp.sparse.issparse(self.a):
             if self.aTa is not None:
-                self.Q_conditional = self.Q_prior - d_matrix.diagonal()[0] * self.aTa
+                # self.Q_conditional = self.Q_prior - d_matrix.diagonal()[0] * self.aTa
+                self.Q_conditional = self.Q_prior - d_matrix_diagonal_0 * self.aTa
             else:
                 self.Q_conditional = self.Q_prior - self.a.T @ d_matrix @ self.a
             # self.Q_conditional = self.Q_prior - self.a.T @ d_matrix @ self.a
         else:
             if self.aTa is not None:
                 self.Q_conditional = (
-                    self.Q_prior.toarray() - d_matrix.diagonal()[0] * self.aTa
+                    # self.Q_prior.toarray() - d_matrix.diagonal()[0] * self.aTa
+                    self.Q_prior.toarray() - d_matrix_diagonal_0 * self.aTa
                 )
             else:
                 self.Q_conditional = (
@@ -540,7 +551,7 @@ class Model(ABC):
             kwargs["h2"] = float(self.theta[0])
             likelihood = self.submodels[0].evaluate_likelihood(eta, self.y, **kwargs)
         else:
-            likelihood = self.likelihood.evaluate_likelihood(
+            likelihood = self.likelihood.evaluate_sum_likelihood(
                 eta, self.y, theta=self.theta[self.hyperparameters_idx[-1] :]
             )
 

--- a/src/dalia/likelihoods/binomial.py
+++ b/src/dalia/likelihoods/binomial.py
@@ -43,7 +43,7 @@ class BinomialLikelihood(Likelihood):
         eta: NDArray,
         y: NDArray,
         **kwargs,
-    ) -> float:
+    ) -> NDArray:
         """Evalutate the a binomial likelihood.
 
         Parameters
@@ -64,9 +64,10 @@ class BinomialLikelihood(Likelihood):
         """
         linkEta: NDArray = self.link_function(eta)
 
-        likelihood: float = xp.dot(y, xp.log(linkEta)) + xp.dot(
-            self.n_trials - y, xp.log(1 - linkEta)
-        )
+        # likelihood: float = xp.dot(y, xp.log(linkEta)) + xp.dot(
+        #     self.n_trials - y, xp.log(1 - linkEta)
+        # )
+        likelihood = y * xp.log(linkEta) + (self.n_trials - y) * xp.log(1 - linkEta)
 
         return likelihood
 

--- a/src/dalia/likelihoods/gaussian.py
+++ b/src/dalia/likelihoods/gaussian.py
@@ -21,7 +21,7 @@ class GaussianLikelihood(Likelihood):
         eta: NDArray,
         y: NDArray,
         **kwargs,
-    ) -> float:
+    ) -> NDArray:
         """Evaluate a Gaussian likelihood.
 
         Notes
@@ -55,9 +55,8 @@ class GaussianLikelihood(Likelihood):
         yEta = eta - y
         # print("xp.exp(theta) in lh:", xp.exp(theta))
 
-        likelihood: float = (
-            0.5 * theta * self.n_observations - 0.5 * xp.exp(theta) * yEta.T @ yEta
-        )
+        likelihood = 0.5 * theta - 0.5 * xp.exp(theta) * yEta * yEta
+        
 
         return likelihood
 

--- a/src/dalia/likelihoods/poisson.py
+++ b/src/dalia/likelihoods/poisson.py
@@ -18,7 +18,7 @@ class PoissonLikelihood(Likelihood):
         config: PoissonLikelihoodConfig,
     ) -> None:
         """Initializes the Poisson likelihood."""
-        super().__init__(config, n_observations)
+        super().__init__(n_observations, config)
 
         # Load the extra coeficients for Poisson likelihood
         try:
@@ -37,8 +37,9 @@ class PoissonLikelihood(Likelihood):
         eta: NDArray,
         y: NDArray,
         **kwargs,
-    ) -> float:
-        likelihood: float = xp.dot(eta, y) - xp.sum(self.e * xp.exp(eta))
+    ) -> NDArray:
+        # likelihood: float = xp.dot(eta, y) - xp.sum(self.e * xp.exp(eta))
+        likelihood = eta * y - self.e * xp.exp(eta)
 
         return likelihood
 

--- a/src/dalia/models/coregional_model.py
+++ b/src/dalia/models/coregional_model.py
@@ -632,7 +632,7 @@ class CoregionalModel(Model):
             # d_list[i] = model.likelihood.evaluate_hessian_likelihood(**kwargs)
             d_vec[
                 self.n_observations_idx[i] : self.n_observations_idx[i + 1]
-            ] = model.likelihood.evaluate_hessian_likelihood(**kwargs).diagonal()
+            ] = model.likelihood.hessian_likelihood(**kwargs).diagonal()
 
         self.Qconditional = self.custom_Q_ATDA(
             Q=self.Q_prior,
@@ -653,7 +653,7 @@ class CoregionalModel(Model):
 
         gradient_vector_list = []
         for i, model in enumerate(self.models):
-            gradient_likelihood = model.likelihood.evaluate_gradient_likelihood(
+            gradient_likelihood = model.likelihood.gradient_likelihood(
                 eta=eta[self.n_observations_idx[i] : self.n_observations_idx[i + 1]],
                 y=self.y[self.n_observations_idx[i] : self.n_observations_idx[i + 1]],
                 theta=float(self.theta[self.hyperparameters_idx[i + 1] - 1]),

--- a/src/dalia/models/coregional_model.py
+++ b/src/dalia/models/coregional_model.py
@@ -630,9 +630,19 @@ class CoregionalModel(Model):
                 }
 
             # d_list[i] = model.likelihood.evaluate_hessian_likelihood(**kwargs)
+            kwargs["y"] = self.y[self.n_observations_idx[i] : self.n_observations_idx[i + 1]]
+            hessian = model.likelihood.hessian_likelihood(**kwargs)
+            if hessian.ndim == 1:
+                diag = hessian
+            elif hessian.ndim == 2:
+                diag = hessian.diagonal()
+            else:
+                raise ValueError(
+                    "Hessian of the likelihood must be either 1D or 2D array."
+                )
             d_vec[
                 self.n_observations_idx[i] : self.n_observations_idx[i + 1]
-            ] = model.likelihood.hessian_likelihood(**kwargs).diagonal()
+            ] = diag
 
         self.Qconditional = self.custom_Q_ATDA(
             Q=self.Q_prior,
@@ -682,7 +692,7 @@ class CoregionalModel(Model):
     ) -> float:
         likelihood: float = 0.0
         for i, model in enumerate(self.models):
-            likelihood += model.likelihood.evaluate_likelihood(
+            likelihood += model.likelihood.evaluate_sum_likelihood(
                 eta=eta[self.n_observations_idx[i] : self.n_observations_idx[i + 1]],
                 y=self.y[self.n_observations_idx[i] : self.n_observations_idx[i + 1]],
                 theta=float(self.theta[self.hyperparameters_idx[i + 1] - 1]),

--- a/src/dalia/submodels/brainiac.py
+++ b/src/dalia/submodels/brainiac.py
@@ -98,6 +98,8 @@ class BrainiacSubModel(SubModel):
 
         return likelihood
 
+    # TODO/NOTE: Maybe specialize the Gaussian likelihood in its own class
+    # and have BrainiacSubModel use it as its likelihood?
     def evaluate_gradient_likelihood(
         self, eta: NDArray, y: NDArray, **kwargs
     ) -> NDArray:


### PR DESCRIPTION
Implements finite-difference 5-point stencil for computing the gradient and hessian of the likelihood. Also introduces small API changes, such as the following:
- The `Likelihood` class now has two new methods, `finite_difference_gradient_likelihood` and `finite_difference_hessian_likelihood`, that implement the approximations.
- Likelihood configuration now has a `method` attribute that takes values in `["exact", "finite-difference"]`. The attribute can be used to switch between the analytical formula for gradients and the finite-difference approximation. Default value is `"exact"`.
- The `method` attribute is used in the new methods `gradient_likelihood` and `hessian_likelihood` that call `evaluate_<x>_likelihood` or `finite_difference_<x>_likelihood` (x is gradient or hessian) accordingly.
- To facilitate the computation of the finite-difference approximation, the `evaluate_likelihood` method now returns the full vector instead of the sum.
- The `Likelihood` class now has an `evaluate_sum_likelihood` method that calls `evaluate_likelihood` and sums up the vector entries.
