### PR TITLE
MAINT: Fixed scalar conversion from 0-Dim array

### DIFF
--- a/src/dalia/core/dalia.py
+++ b/src/dalia/core/dalia.py
@@ -703,7 +703,8 @@ class DALIA:
                 log_prior_hyperparameters: float = (
                     self.model.evaluate_log_prior_hyperparameters()
                 )
-                likelihood: float = float(self.model.evaluate_likelihood(eta=eta))
+
+                likelihood: float = self.model.evaluate_likelihood(eta=eta)
                 prior_latent_parameters: float = (
                     self._evaluate_prior_latent_parameters()
                 )

--- a/src/dalia/core/likelihood.py
+++ b/src/dalia/core/likelihood.py
@@ -37,11 +37,14 @@ class Likelihood(ABC):
         **kwargs : optional
             Hyperparameters for likelihood.
 
-
         Returns
         -------
         likelihood : float
             Likelihood.
+
+        Implementation Notes:
+        ---------------------
+        - This function does not guarantee that the likelihood is a scalar. If evaluated from numpy/cupy dot product it will be a ndarray of shape (1,).
         """
         pass
 

--- a/src/dalia/core/model.py
+++ b/src/dalia/core/model.py
@@ -32,6 +32,7 @@ from dalia.submodels import (
     SpatioTemporalSubModel,
 )
 from dalia.utils import add_str_header, boxify, scaled_logit
+from dalia.utils.scalar_ndarray import ensure_scalar
 
 
 class Model(ABC):
@@ -534,7 +535,20 @@ class Model(ABC):
         return theta_interpret
 
     def evaluate_likelihood(self, eta: NDArray, **kwargs) -> float:
-        """Evaluate the likelihood."""
+        """Evaluate the likelihood.
+        
+        Parameters
+        ----------
+        eta : NDArray
+            Linear predictor.
+        kwargs : dict
+            Additional arguments for the likelihood evaluation. These parameters are model dependent.
+
+        Returns
+        -------
+        likelihood : float
+            The evaluated likelihood.
+        """
 
         if isinstance(self.submodels[0], BrainiacSubModel):
             kwargs["h2"] = float(self.theta[0])
@@ -544,7 +558,9 @@ class Model(ABC):
                 eta, self.y, theta=self.theta[self.hyperparameters_idx[-1] :]
             )
 
-        return likelihood
+        return ensure_scalar(likelihood)
+
+        
 
     def __str__(self) -> str:
         """String representation of the model."""

--- a/src/dalia/likelihoods/binomial.py
+++ b/src/dalia/likelihoods/binomial.py
@@ -53,14 +53,14 @@ class BinomialLikelihood(Likelihood):
         y : NDArray
             Vector of the observations.
 
-        Notes
-        -----
-        For now only a sigmoid link-function is implemented.
-
         Returns
         -------
         likelihood : float
             Likelihood.
+
+        Notes
+        -----
+        - For now only a sigmoid link-function is implemented.
         """
         linkEta: NDArray = self.link_function(eta)
 

--- a/src/dalia/models/coregional_model.py
+++ b/src/dalia/models/coregional_model.py
@@ -21,6 +21,7 @@ from dalia.utils import (
     boxify,
     free_unused_gpu_memory,
 )
+from dalia.utils.scalar_ndarray import ensure_scalar
 
 
 class CoregionalModel(Model):
@@ -670,7 +671,13 @@ class CoregionalModel(Model):
         return information_vector
 
     def is_likelihood_gaussian(self) -> bool:
-        """Check if the likelihood is Gaussian."""
+        """Check if the likelihood is Gaussian.
+        
+        Returns
+        -------
+        is_gaussian : bool
+            True if the likelihood is Gaussian, False otherwise.
+        """
         for model in self.models:
             if not model.is_likelihood_gaussian():
                 return False
@@ -680,6 +687,25 @@ class CoregionalModel(Model):
         self,
         eta: NDArray,
     ) -> float:
+        """Evaluate the likelihood.
+        
+        Parameters
+        ----------
+        eta : NDArray
+            Linear predictor.
+        kwargs : dict
+            Additional arguments for the likelihood evaluation. These parameters are model dependent.
+
+        Returns
+        -------
+        likelihood : float
+            The evaluated likelihood.
+
+        Implementation Notes:
+        ---------------------
+        - The likelihood is evaluated for each model and then summed up to get the total likelihood of the CoregionalModel.
+        - Returned as a scalar for consistency, even if the likelihood is computed as a sum of multiple likelihoods from different models.
+        """
         likelihood: float = 0.0
         for i, model in enumerate(self.models):
             likelihood += model.likelihood.evaluate_likelihood(
@@ -687,8 +713,8 @@ class CoregionalModel(Model):
                 y=self.y[self.n_observations_idx[i] : self.n_observations_idx[i + 1]],
                 theta=float(self.theta[self.hyperparameters_idx[i + 1] - 1]),
             )
-
-        return likelihood
+   
+        return ensure_scalar(likelihood)
 
     def evaluate_log_prior_hyperparameters(self) -> float:
         """Evaluate the log prior hyperparameters."""

--- a/src/dalia/utils/__init__.py
+++ b/src/dalia/utils/__init__.py
@@ -30,6 +30,7 @@ from dalia.utils.print_utils import (
     boxify,
 )
 from dalia.utils.spmatrix_utils import bdiag_tiling, extract_diagonal, memory_footprint
+from .scalar_ndarray import ensure_scalar
 
 __all__ = [
     "get_available_devices",

--- a/src/dalia/utils/scalar_ndarray.py
+++ b/src/dalia/utils/scalar_ndarray.py
@@ -1,0 +1,41 @@
+from dalia import xp
+
+
+def ensure_scalar(value: float | xp.ndarray) -> float:
+    """ Ensure that the input value is a scalar float. If the input is a 1-element array, extract the scalar value. 
+    If the input is an array with more than 1 element, raise an error.
+    
+    Parameters
+    ----------
+    value : float or xp.ndarray
+        The value to ensure is a scalar float.
+
+    Returns
+    -------
+    float
+        The scalar float value.
+
+    Raises
+    ------
+    ValueError
+        If the input is not a float or a 1-element array.
+
+    """
+    if isinstance(value, float):
+        return value
+
+    if isinstance(value, xp.ndarray):
+        # Need to handle the case where the array is 0-dimensional 
+        # (i.e., a scalar wrapped in an array)
+        if value.ndim == 0:
+            return float(value.item())
+
+        if value.size > 1:
+            raise ValueError(
+                f"value evaluation returned an array of size {value.size}, expected a scalar."
+            )
+        return float(value[0])
+
+    raise ValueError(
+        f"value evaluation returned an object of type {type(value)}, expected a float or a 1-element array."
+    )


### PR DESCRIPTION
-> Bug arose in Numpy/Cupy 2.4

The problem is that they are 3 types of potential way to store a scalar:
- Python native float()
- 0-Dimmensional ndarray
- x-dimmensional ndarray
In the new version of numpy they changed the behavior of the 0-Dim array, so the implicit conversion: `float(0-dim ndarray)` would now try to be a `float(x-dim ndarray)`, which would then fail.

I added a util function in `utils/scalar_ndarray.py`. Both Model() and CoregionalModel() are ensured to return a scalar for the likelihood evaluation. However I didn't force it directly in the likelihood themself because of the 2 following reasons:
1. I expected that maybe one day we'll have likelihood evaluation that could return several values, that then get treated by the Model()?
2. In the current architecture of the code I woudl have had to add the `ensure_scalar` function in each sub-implementation. Otherwise I would have had to modify the Likelihood class to have a `evaluate_likelihood()`, that would ensure the check, and a `_evaluate_likelihood()` that would be the one specified by the daughter classes. And it felt to big of an architectural modification for such a small type bug.